### PR TITLE
Enable logging interceptor only during DEBUG

### DIFF
--- a/jwt-android/app/src/main/java/com/andrewcwang/jwtauth/networking/AuthService.kt
+++ b/jwt-android/app/src/main/java/com/andrewcwang/jwtauth/networking/AuthService.kt
@@ -50,7 +50,11 @@ interface AuthService {
             val client = OkHttpClient().newBuilder()
                     .authenticator(AccessTokenAuthenticator(authManager))
                     .addInterceptor(HeaderInterceptor(authManager))
-                    .addInterceptor(loggingInterceptor)
+                    .also {
+                        if(BuildConfig.DEBUG) {
+                            it.addInterceptor(loggingInterceptor)
+                        }
+                    }
                     .build()
 
             // Create the service


### PR DESCRIPTION
[//]: # (Thanks for helping us out! Cache invalidation sucks, so your help is greatly appreciated!)

## Description

[//]: # (What're you proposing?)
Only apply the logging interceptor during build debug. Ref: https://www.reddit.com/r/androiddev/comments/kexf4a/template_app_django_showcasing_jwt_auth_and/gg5230q?utm_source=share&utm_medium=web2x&context=3


## Rationale

[//]: # (Why should we implement it?)
Don't clog up logs with relatively meaningless info, increasing storage/memory consumption.